### PR TITLE
Tiny typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Installation
 
 using pip:
 
-    pip caribou
+    pip install caribou
 
 or, [download][download] and extract the most code in the repo, and
 run:


### PR DESCRIPTION
adds the `install` keyword to pip