### PR TITLE
Fix caribou cli list bug

### DIFF
--- a/bin/caribou
+++ b/bin/caribou
@@ -71,7 +71,7 @@ def list_migrations_command(args):
     migration_dir = args.migration_dir
     _print_info("Migrations in [%s]:" % migration_dir)
     _print_info("")
-    migrations = caribou.get_migrations(migration_dir)
+    migrations = caribou.load_migrations(migration_dir)
     for migration in migrations:
         version = migration.get_version()
         path = migration.path

--- a/caribou.py
+++ b/caribou.py
@@ -257,7 +257,7 @@ MIGRATION_TEMPLATE = """\
 \"\"\"
 This module contains a Caribou migration.
 
-Migration Name: %(name)s 
+Migration Name: %(name)s
 Migration Version: %(version)s
 \"\"\"
 


### PR DESCRIPTION
The caribou CLI encounters a bug when trying to use the `list` command:

```
AttributeError: module 'caribou' has no attribute 'get_migrations'
```

This PR fixes this issue.