### PR TITLE
Fix for imp module removal

### DIFF
--- a/caribou.py
+++ b/caribou.py
@@ -11,10 +11,10 @@ __author__ = 'clutchski@gmail.com'
 import contextlib
 import datetime
 import glob
-import imp
 import os.path
 import sqlite3
 import traceback
+from importlib.machinery import SourceFileLoader
 
 # statics
 
@@ -79,7 +79,7 @@ class Migration(object):
         while self.name.startswith('_'):
             self.name = self.name[1:]
         try:
-            self.module = imp.load_source(self.module_name, path)
+            self.module = SourceFileLoader(self.module_name, path).load_module()
         except:
             msg = "Invalid migration %s: %s" % (path, traceback.format_exc())
             raise InvalidMigrationError(msg)


### PR DESCRIPTION
This fixes an error occurring on Python 3.12+ , where imp module (deprecated since Python 3.4) has been removed.